### PR TITLE
Rename repo to auth-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
-# gotrue-go
+# auth-go
 
-![example branch parameter](https://github.com/supabase-community/gotrue-go/actions/workflows/test.yaml/badge.svg?branch=main)
-[![codecov](https://codecov.io/gh/supabase-community/gotrue-go/branch/main/graph/badge.svg?token=JQQJKETMRX)](https://codecov.io/gh/supabase-community/gotrue-go)
-![GitHub](https://img.shields.io/github/license/supabase-community/gotrue-go)
-[![Go Reference](https://pkg.go.dev/badge/github.com/supabase-community/gotrue-go.svg)](https://pkg.go.dev/github.com/supabase-community/gotrue-go)
+![example branch parameter](https://github.com/supabase-community/auth-go/actions/workflows/test.yaml/badge.svg?branch=main)
+[![codecov](https://codecov.io/gh/supabase-community/auth-go/branch/main/graph/badge.svg?token=JQQJKETMRX)](https://codecov.io/gh/supabase-community/auth-go)
+![GitHub](https://img.shields.io/github/license/supabase-community/auth-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/supabase-community/auth-go.svg)](https://pkg.go.dev/github.com/supabase-community/auth-go)
 
+A Golang client library for the [Supabase Auth](https://github.com/supabase/auth) API.
 
-A Golang client library for the [Supabase GoTrue](https://github.com/supabase/gotrue) API.
-
-> ⚠️ Using [`netlify/gotrue`](https://github.com/netlify/gotrue)?
->
-> The types in this library assume you are interacting with a Supabase GoTrue server. It is very unlikely to work with a Netlify GoTrue server.
-
-For more information about the Supabase fork of GoTrue, [check out the project here](https://github.com/supabase/gotrue).
+For more information about the Supabase fork of GoTrue, [check out the project here](https://github.com/supabase/auth).
 
 ## Project status
 
@@ -25,14 +20,15 @@ The endpoints for SSO SAML are not tested and `POST /sso/saml/acs` does not prov
 ### Install
 
 ```sh
-go get github.com/supabase-community/gotrue-go
+go get github.com/supabase-community/auth-go
 ```
 
 ### Usage
+
 ```go
 package main
 
-import "github.com/supabase-community/gotrue-go"
+import "github.com/supabase-community/auth-go"
 
 const (
     projectReference = "<your_supabase_project_reference>"
@@ -41,13 +37,13 @@ const (
 
 func main() {
     // Initialise client
-    client := gotrue.New(
+    client := auth.New(
         projectReference,
         apiKey,
     )
 
     // Log in a user (get access and refresh tokens)
-    resp, err := client.Token(gotrue.TokenRequest{
+    resp, err := client.Token(auth.TokenRequest{
         GrantType: "password",
         Email: "<user_email>",
         Password: "<user_password>",
@@ -66,12 +62,12 @@ The client can be customized with the options below.
 In all cases, **these functions return a copy of the client**. To use the configured value, you must use the returned client. For example:
 
 ```go
-client := gotrue.New(
+client := auth.New(
     projectRefernce,
     apiKey,
 )
 
-token, err := client.Token(gotrue.TokenRequest{
+token, err := client.Token(auth.TokenRequest{
         GrantType: "password",
         Email: email,
         Password: password,
@@ -90,39 +86,52 @@ if err != nil {
 ```
 
 ### WithToken
+
 ```go
 func (*Client) WithToken(token string) *Client
 ```
 
 Returns a client that will use the provided token in the `Authorization` header on all requests.
 
-### WithCustomGoTrueURL
+### WithCustomAuthURL
+
 ```go
-func (*Client) WithCustomGoTrueURL(url string) *Client
+func (*Client) WithCustomAuthURL(url string) *Client
 ```
 
-Returns a client that will use the provided URL instead of `https://<project_ref>.supabase.com/auth/v1/`. This allows you to use the client with your own deployment of the GoTrue server without relying on a Supabase-hosted project.
+Returns a client that will use the provided URL instead of `https://<project_ref>.supabase.com/auth/v1/`. This allows you to use the client with your own deployment of the Auth server without relying on a Supabase-hosted project.
 
 ### WithClient
+
 ```go
 func (*Client) WithClient(client http.Client) *Client
 ```
 
-By default, the library uses a default http.Client. If you want to configure your own, pass one in using `WithClient` and it will be used for all requests made with the returned `*gotrue.Client`.
+By default, the library uses a default http.Client. If you want to configure your own, pass one in using `WithClient` and it will be used for all requests made with the returned `*auth.Client`.
 
 ## Testing
 
 > You don't need to know this stuff to use the library
 
-The library is tested against a real GoTrue server running in a docker image. This also requires a postgres server to back it. These are configured using docker compose.
+The library is tested against a real Auth server running in a docker image. This also requires a postgres server to back it. These are configured using docker compose.
 
 To run these tests, simply `make test`.
 
 To interact with docker compose, you can also use `make up` and `make down`.
 
-## Differences from gotrue-js
+## Differences from auth-js
 
-Prior users of [`gotrue-js`](https://github.com/supabase/gotrue-js) may be familiar with its subscription mechanism and session management - in line with its ability to be used as a client-side authentication library, in addition to use on the server.
+Prior users of [`auth-js`](https://github.com/supabase/auth-js) may be familiar with its subscription mechanism and session management - in line with its ability to be used as a client-side authentication library, in addition to use on the server.
 
-As Go is typically used on the backend, this library acts purely as a convenient wrapper for interacting with a GoTrue server. It provides no session management or subscription mechanism.
+As Go is typically used on the backend, this library acts purely as a convenient wrapper for interacting with a Auth server. It provides no session management or subscription mechanism.
 
+## Migrating from gotrue-go
+
+This repository was created as a duplicate of [gotrue-go](https://github.com/supabase-community/gotrue-go).
+
+As part of renaming the package, breaking changes to the API were also introduced, to keep consistency with the new naming. The changes can generally be boiled down to:
+
+1. Rename instances of `gotrue-go` to `auth-go`
+2. Rename instances of `GoTrue` to `Auth`
+
+There are a small number of exceptions where required to maintain compatibility with the implementation of the Auth server. No other changes were introduced, so you should find the exact same functionality under a very similar name if updating your codebase from gotrue-go to auth-go.

--- a/api.go
+++ b/api.go
@@ -1,12 +1,12 @@
-package gotrue
+package auth
 
 import (
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
-// Create a new client using gotrue.New, then you can call the methods below.
+// Create a new client using auth.New, then you can call the methods below.
 //
 // Some methods require bearer token authentication. To set the bearer token,
 // use the WithToken(token) method.
@@ -15,15 +15,15 @@ type Client interface {
 	// Options:
 
 	// By default, the client will use the supabase project reference and assume
-	// you are connecting to the GoTrue server as part of a supabase project.
-	// To connect to a GoTrue server hosted elsewhere, you can specify a custom
+	// you are connecting to the Auth server as part of a supabase project.
+	// To connect to a Auth server hosted elsewhere, you can specify a custom
 	// URL using this method.
 	//
 	// It returns a copy of the client, so only requests made with the returned
 	// copy will use the new URL.
 	//
 	// This method does not validate the URL you pass in.
-	WithCustomGoTrueURL(url string) Client
+	WithCustomAuthURL(url string) Client
 	// WithToken sets the access token to pass when making admin requests that
 	// require token authentication.
 	//
@@ -164,7 +164,7 @@ type Client interface {
 
 	// GET /health
 	//
-	// Check the health of the GoTrue server.
+	// Check the health of the Auth server.
 	HealthCheck() (*types.HealthCheckResponse, error)
 
 	// POST /invite
@@ -217,7 +217,7 @@ type Client interface {
 
 	// GET /settings
 	//
-	// Returns the publicly available settings for this gotrue instance.
+	// Returns the publicly available settings for this auth instance.
 	GetSettings() (*types.SettingsResponse, error)
 
 	// POST /signup
@@ -294,7 +294,7 @@ type Client interface {
 	// provided for convenience and will simply POST your HTTP request to the
 	// endpoint and return the response.
 	//
-	// For required parameters, see the SAML spec or the GoTrue implementation
+	// For required parameters, see the SAML spec or the Auth implementation
 	// of this endpoint.
 	//
 	// The server may issue redirects. Using the default HTTP client, this method
@@ -317,7 +317,7 @@ type Client interface {
 	// If successful, the server returns a redirect to the provider's authorization
 	// URL. The client will follow it and return the final HTTP response.
 	//
-	// GoTrue allows you to skip following the redirect by setting SkipHTTPRedirect
+	// Auth allows you to skip following the redirect by setting SkipHTTPRedirect
 	// on the request struct. In this case, the URL to redirect to will be returned
 	// in the response.
 	SSO(req types.SSORequest) (*types.SSOResponse, error)

--- a/client.go
+++ b/client.go
@@ -1,14 +1,14 @@
-package gotrue
+package auth
 
 import (
 	"errors"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/endpoints"
+	"github.com/supabase-community/auth-go/endpoints"
 )
 
 var (
-	ErrInvalidProjectReference = errors.New("cannot create gotrue client: invalid project reference")
+	ErrInvalidProjectReference = errors.New("cannot create auth client: invalid project reference")
 )
 
 var _ Client = &client{}
@@ -17,13 +17,13 @@ type client struct {
 	*endpoints.Client
 }
 
-// Set up a new GoTrue client.
+// Set up a new Auth client.
 //
 // projectReference: The project reference is the unique identifier for your
 // Supabase project. It can be found in the Supabase dashboard under project
 // settings as Reference ID.
 //
-// apiKey: The API key is used to authenticate requests to the GoTrue server.
+// apiKey: The API key is used to authenticate requests to the Auth server.
 // This should be your anon key.
 //
 // This function does not validate your project reference. Requests will fail
@@ -34,9 +34,9 @@ func New(projectReference string, apiKey string) Client {
 	}
 }
 
-func (c client) WithCustomGoTrueURL(url string) Client {
+func (c client) WithCustomAuthURL(url string) Client {
 	return &client{
-		Client: c.Client.WithCustomGoTrueURL(url),
+		Client: c.Client.WithCustomAuthURL(url),
 	}
 }
 

--- a/endpoints/adminaudit.go
+++ b/endpoints/adminaudit.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tomnomnom/linkheader"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const adminAuditPath = "/admin/audit"

--- a/endpoints/admingeneratelink.go
+++ b/endpoints/admingeneratelink.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const adminGenerateLinkPath = "/admin/generate_link"

--- a/endpoints/adminssoproviders.go
+++ b/endpoints/adminssoproviders.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const adminSSOPath = "/admin/sso/providers"

--- a/endpoints/adminusers.go
+++ b/endpoints/adminusers.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const adminUsersPath = "/admin/users"

--- a/endpoints/adminusersfactors.go
+++ b/endpoints/adminusersfactors.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 // GET /admin/users/{user_id}/factors

--- a/endpoints/authorize.go
+++ b/endpoints/authorize.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const authorizePath = "/authorize"

--- a/endpoints/client.go
+++ b/endpoints/client.go
@@ -24,7 +24,7 @@ func New(projectReference string, apiKey string) *Client {
 	}
 }
 
-func (c Client) WithCustomGoTrueURL(url string) *Client {
+func (c Client) WithCustomAuthURL(url string) *Client {
 	return &Client{
 		client:  c.client,
 		baseURL: url,

--- a/endpoints/factors.go
+++ b/endpoints/factors.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const factorsPath = "/factors"

--- a/endpoints/health.go
+++ b/endpoints/health.go
@@ -6,14 +6,14 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 var healthPath = "/health"
 
 // GET /health
 //
-// Check the health of the GoTrue server.
+// Check the health of the Auth server.
 func (c *Client) HealthCheck() (*types.HealthCheckResponse, error) {
 	r, err := c.newRequest(healthPath, http.MethodGet, nil)
 	if err != nil {

--- a/endpoints/invite.go
+++ b/endpoints/invite.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const invitePath = "/invite"

--- a/endpoints/magiclink.go
+++ b/endpoints/magiclink.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const magiclinkPath = "/magiclink"

--- a/endpoints/otp.go
+++ b/endpoints/otp.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const otpPath = "/otp"

--- a/endpoints/recover.go
+++ b/endpoints/recover.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const recoverPath = "/recover"

--- a/endpoints/saml.go
+++ b/endpoints/saml.go
@@ -47,7 +47,7 @@ func (c *Client) SAMLMetadata() ([]byte, error) {
 // provided for convenience and will simply POST your HTTP request to the
 // endpoint and return the response.
 //
-// For required parameters, see the SAML spec or the GoTrue implementation
+// For required parameters, see the SAML spec or the Auth implementation
 // of this endpoint.
 //
 // The server may issue redirects. Using the default HTTP client, this method

--- a/endpoints/settings.go
+++ b/endpoints/settings.go
@@ -6,14 +6,14 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 var settingsPath = "/settings"
 
 // GET /settings
 //
-// Returns the publicly available settings for this gotrue instance.
+// Returns the publicly available settings for this auth instance.
 func (c *Client) GetSettings() (*types.SettingsResponse, error) {
 	r, err := c.newRequest(settingsPath, http.MethodGet, nil)
 	if err != nil {

--- a/endpoints/signup.go
+++ b/endpoints/signup.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const signupPath = "/signup"

--- a/endpoints/sso.go
+++ b/endpoints/sso.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const ssoPath = "/sso"
@@ -19,7 +19,7 @@ const ssoPath = "/sso"
 // If successful, the server returns a redirect to the provider's authorization
 // URL. The client will follow it and return the final HTTP response.
 //
-// GoTrue allows you to skip following the redirect by setting SkipHTTPRedirect
+// Auth allows you to skip following the redirect by setting SkipHTTPRedirect
 // on the request struct. In this case, the URL to redirect to will be returned
 // in the response.
 func (c *Client) SSO(req types.SSORequest) (*types.SSOResponse, error) {

--- a/endpoints/token.go
+++ b/endpoints/token.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const tokenPath = "/token"

--- a/endpoints/user.go
+++ b/endpoints/user.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 var userPath = "/user"

--- a/endpoints/verify.go
+++ b/endpoints/verify.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 const verifyPath = "/verify"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/supabase-community/gotrue-go
+module github.com/supabase-community/auth-go
 
 go 1.18
 

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,24 +1,28 @@
-# Testing gotrue-go
+# Testing auth-go
 
 ## Postgres set up
 The postgres server requires some set up beyond the default postgres docker image. For example, it needs to set up the `supabase_auth_admin` user and the `auth` namespace. This is done using `testing/init_postgres.sh`, which is copied into the postgres image's entrypoint directory so that it runs on startup.
 
-This script in run by the `postgres` user, as configured for the postgres image in `docker-compose`. This is why the docker image is configured with `postgres:root`, but the GoTrue server connects to postgres using the newly created `supabase_auth_admin` user, which also uses `root` as its password.
+This script in run by the `postgres` user, as configured for the postgres image in `docker-compose`. This is why the docker image is configured with `postgres:root`, but the Auth server connects to postgres using the newly created `supabase_auth_admin` user, which also uses `root` as its password.
 
-This is based on the same set up in the [supabase/gotrue](https://github.com/supabase/gotrue) repo.
+This is based on the same set up in the [supabase/auth](https://github.com/supabase/auth) repo.
 
 ### Start up
-As postgres can take some time to startup and run the entrypoint on it's first run, the GoTrue server will often fail to connect to postgres on the first attempt. This is normal, and it should be restarted by docker compose and eventually succeed in connecting and running migrations.
 
-Our tests can also sometimes fail by running too early. `TestMain(m *testing.M)` in `client_test.go` should ensure the GoTrue server is ready for requests before running any tests.
+As postgres can take some time to startup and run the entrypoint on it's first run, the Auth server will often fail to connect to postgres on the first attempt. This is normal, and it should be restarted by docker compose and eventually succeed in connecting and running migrations.
+
+Our tests can also sometimes fail by running too early. `TestMain(m *testing.M)` in `client_test.go` should ensure the Auth server is ready for requests before running any tests.
 
 ### Volume
-To ensure a clean start, the postgres container does not use a volume, meaning all its data is lost every time the container stops.
+
+To ensure a clean start, the postgres container does not use a volume, meaning all of its data is lost every time the container stops.
 
 ## Multiple servers
-We actually spin up 3 GoTrue instances, each with different configurations, to facilitate testing the client where the server config affects what gets returned. For example, if autoconfirm (of the user's email/phone) is disabled, signup returns a `types.User`. If autoconfirm is enabled, a `types.Session` is returned instead. Autoconfirm is a configuration on the server, so there's no easy way to test this without running multiple servers.
+
+We actually spin up 3 Auth instances, each with different configurations, to facilitate testing the client where the server config affects what gets returned. For example, if autoconfirm (of the user's email/phone) is disabled, signup returns a `types.User`. If autoconfirm is enabled, a `types.Session` is returned instead. Autoconfirm is a configuration on the server, so there's no easy way to test this without running multiple servers.
 
 They all seem to be happy enough interacting with the same database, though.
 
 ## Rate limiting
-GoTrue implements rate limits. We can configure high limits for HTTP requests, but in the case of signup requests, for example, there are further tests that a confirmation email wasn't sent too recently (typically within the last 60 seconds). Instead, we set the email rate limit to 1 request per nanosecond.
+
+Auth implements rate limits. We can configure high limits for HTTP requests, but in the case of signup requests, for example, there are further tests that a confirmation email wasn't sent too recently (typically within the last 60 seconds). Instead, we set the email rate limit to 1 request per nanosecond.

--- a/integration_test/adminaudit_test.go
+++ b/integration_test/adminaudit_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 // This test creates some audit logs, then retrieves them with pagination.

--- a/integration_test/admingeneratelink_test.go
+++ b/integration_test/admingeneratelink_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestAdminGenerateLink(t *testing.T) {

--- a/integration_test/adminusers_test.go
+++ b/integration_test/adminusers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestAdminCreateUser(t *testing.T) {

--- a/integration_test/adminusersfactors_test.go
+++ b/integration_test/adminusersfactors_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestAdminListUserFactors(t *testing.T) {

--- a/integration_test/authorize_test.go
+++ b/integration_test/authorize_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestAuthorize(t *testing.T) {

--- a/integration_test/factors_test.go
+++ b/integration_test/factors_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestFactors(t *testing.T) {

--- a/integration_test/health_test.go
+++ b/integration_test/health_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go"
+	"github.com/supabase-community/auth-go"
 )
 
 func TestHealth(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	client := gotrue.New(projectReference, apiKey).WithCustomGoTrueURL("http://localhost:9999")
+	client := auth.New(projectReference, apiKey).WithCustomAuthURL("http://localhost:9999")
 	health, err := client.HealthCheck()
 	require.NoError(err)
 	assert.Equal(health.Name, "GoTrue")

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go"
+	"github.com/supabase-community/auth-go"
 )
 
 const (
@@ -25,16 +25,16 @@ const (
 
 var (
 	// Global clients are used for all tests in this package.
-	client               gotrue.Client
-	autoconfirmClient    gotrue.Client
-	signupDisabledClient gotrue.Client
+	client               auth.Client
+	autoconfirmClient    auth.Client
+	signupDisabledClient auth.Client
 
 	// Used to validate UUIDs.
 	uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$`)
 )
 
 func randomString(n int) string {
-	// Using all lower case because email addresses are lowercased by GoTrue.
+	// Using all lower case because email addresses are lowercased by Auth.
 	letterBytes := "abcdefghijklmnopqrstuvwxyz"
 	b := make([]byte, n)
 	for i := range b {
@@ -74,16 +74,16 @@ func adminToken() string {
 	return token
 }
 
-func withAdmin(c gotrue.Client) gotrue.Client {
+func withAdmin(c auth.Client) auth.Client {
 	return c.WithToken(adminToken())
 }
 
 func TestMain(m *testing.M) {
 	// Please refer to ./setup/docker-compose.yaml and ./README.md for more info
 	// on this test set up.
-	client = gotrue.New(projectReference, apiKey).WithCustomGoTrueURL("http://localhost:9999")
-	autoconfirmClient = gotrue.New(projectReference, apiKey).WithCustomGoTrueURL("http://localhost:9998")
-	signupDisabledClient = gotrue.New(projectReference, apiKey).WithCustomGoTrueURL("http://localhost:9997")
+	client = auth.New(projectReference, apiKey).WithCustomAuthURL("http://localhost:9999")
+	autoconfirmClient = auth.New(projectReference, apiKey).WithCustomAuthURL("http://localhost:9998")
+	signupDisabledClient = auth.New(projectReference, apiKey).WithCustomAuthURL("http://localhost:9997")
 
 	// Ensure the server is ready before running tests.
 	err := backoff.Retry(
@@ -129,7 +129,7 @@ func TestWithClient(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	c := gotrue.New(projectReference, apiKey).WithCustomGoTrueURL("http://localhost:9999")
+	c := auth.New(projectReference, apiKey).WithCustomAuthURL("http://localhost:9999")
 	h, err := c.HealthCheck()
 	require.NoError(err)
 	assert.Equal("GoTrue", h.Name)

--- a/integration_test/invite_test.go
+++ b/integration_test/invite_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestInvite(t *testing.T) {

--- a/integration_test/logout_test.go
+++ b/integration_test/logout_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestLogout(t *testing.T) {

--- a/integration_test/magiclink_test.go
+++ b/integration_test/magiclink_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestMagiclink(t *testing.T) {

--- a/integration_test/otp_test.go
+++ b/integration_test/otp_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestOTP(t *testing.T) {

--- a/integration_test/reauthenticate_test.go
+++ b/integration_test/reauthenticate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestReauthenticate(t *testing.T) {

--- a/integration_test/recover_test.go
+++ b/integration_test/recover_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestRecover(t *testing.T) {

--- a/integration_test/setup/docker-compose.yaml
+++ b/integration_test/setup/docker-compose.yaml
@@ -1,11 +1,11 @@
 version: "3.9"
 services:
-  gotrue:
+  auth:
     # Signups enabled, auto-confirm off
-    container_name: gotrue
+    container_name: auth
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.157.0
+    image: supabase/auth:v2.160.0
     restart: on-failure
     ports:
       - "9999:9999"
@@ -25,12 +25,12 @@ services:
       GOTRUE_MFA_RATE_LIMIT_CHALLENGE_AND_VERIFY: "1000000"
       GOTRUE_SMTP_MAX_FREQUENCY: "1ns"
 
-  gotrue_autoconfirm:
+  auth_autoconfirm:
     # Signups enabled, auto-confirm on
-    container_name: gotrue_autoconfirm
+    container_name: auth_autoconfirm
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.157.0
+    image: supabase/auth:v2.160.0
     restart: on-failure
     ports:
       - "9998:9998"
@@ -57,12 +57,12 @@ services:
       GOTRUE_EXTERNAL_GITHUB_SECRET: "clientsecretvaluessssh"
       GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI: "http://localhost:3000/callback"
 
-  gotrue_signup_disabled:
+  auth_signup_disabled:
     # Signups disabled
-    container_name: gotrue_signup_disabled
+    container_name: auth_signup_disabled
     depends_on:
       - postgres
-    image: supabase/gotrue:v2.157.0
+    image: supabase/auth:v2.160.0
     restart: on-failure
     ports:
       - "9997:9997"
@@ -88,7 +88,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.postgres.dev
-    container_name: gotrue_postgres
+    container_name: auth_postgres
     ports:
       - "5432:5432"
     environment:

--- a/integration_test/signup_test.go
+++ b/integration_test/signup_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestSignup(t *testing.T) {

--- a/integration_test/token_test.go
+++ b/integration_test/token_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestToken(t *testing.T) {

--- a/integration_test/user_test.go
+++ b/integration_test/user_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestUser(t *testing.T) {

--- a/integration_test/verify_test.go
+++ b/integration_test/verify_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 // These test struggle to really exercise a full verification flow - getting

--- a/types/banduration_test.go
+++ b/types/banduration_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/supabase-community/gotrue-go/types"
+	"github.com/supabase-community/auth-go/types"
 )
 
 func TestBanDuration(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This repo was created as a duplicate of [supabase-community/gotrue-go](https://github.com/supabase-community/gotrue-go), to align with other repo renames (namely, [supabase/gotrue](https://github.com/supabase/gotrue) to [supabase/auth](https://github.com/supabase/auth), and several client libs that have followed suit - see the [supabase-community README](https://github.com/supabase-community) for up-to-date info).

This PR handles the renaming in this repo.

[gotrue-go](https://github.com/supabase-community/gotrue-go) will continue to exist as an archived repo, and will (under normal circumstances) receive no further updates, while this package will continue to be maintained instead.