### PR TITLE
`RedirectTo` in `AuthorizeRequest` and `Code` JSON field tag corrrected in `TokenRequest`

### DIFF
--- a/endpoints/authorize.go
+++ b/endpoints/authorize.go
@@ -49,6 +49,7 @@ func (c *Client) Authorize(req types.AuthorizeRequest) (*types.AuthorizeResponse
 	q := r.URL.Query()
 	q.Add("scopes", req.Scopes)
 	q.Add("provider", string(req.Provider))
+	q.Add("redirect_to", req.RedirectTo)
 
 	verifier := ""
 

--- a/types/api.go
+++ b/types/api.go
@@ -285,6 +285,7 @@ const (
 
 type AuthorizeRequest struct {
 	Provider Provider
+	RedirectTo string
 	FlowType FlowType
 	Scopes   string
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR
- adds a `RedirectTo` field to `types.AuthorizeRequest`. This will be passed along in a request to the `/auth/v1/authorize` endpoint.
- corrects the name of the JSON field tag of `Code` in `types.TokenRequest`

## What is the current behavior?

Currently, there is no `RedirectTo` field in `types.AuthorizeRequest`: #4 
The field Code in `types.TokenRequest` has a wrong JSON name in the struct field tag: #5 

## What is the new behavior?

- Callback route can be passed to the `/auth/v1/authorize` endpoint
- Code exchange for PKCE will now work because the `Code` field's JSON name will be correct when `/auth/v1/token` is called.
