### PR TITLE
Add Pagination Support to GET /admin/users

### DIFF
--- a/api.go
+++ b/api.go
@@ -99,7 +99,7 @@ type Client interface {
 	// Get a list of users.
 	//
 	// Requires admin token.
-	AdminListUsers() (*types.AdminListUsersResponse, error)
+	AdminListUsers(req types.AdminListUsersRequest) (*types.AdminListUsersResponse, error)
 	// GET /admin/users/{user_id}
 	//
 	// Get a user by their user_id.

--- a/endpoints/adminusers.go
+++ b/endpoints/adminusers.go
@@ -53,15 +53,19 @@ func (c *Client) AdminCreateUser(req types.AdminCreateUserRequest) (*types.Admin
 //
 // Get a list of users.
 func (c *Client) AdminListUsers(req types.AdminListUsersRequest) (*types.AdminListUsersResponse, error) {
-	body, err := json.Marshal(req)
+	r, err := c.newRequest(adminUsersPath, http.MethodGet, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := c.newRequest(adminUsersPath, http.MethodGet, bytes.NewBuffer(body))
-	if err != nil {
-		return nil, err
+	q := r.URL.Query()
+	if req.Page != nil {
+		q.Add("page", fmt.Sprintf("%d", *req.Page))
 	}
+	if req.PerPage != nil {
+		q.Add("per_page", fmt.Sprintf("%d", *req.PerPage))
+	}
+	r.URL.RawQuery = q.Encode()
 
 	resp, err := c.client.Do(r)
 	if err != nil {

--- a/endpoints/adminusers.go
+++ b/endpoints/adminusers.go
@@ -52,8 +52,13 @@ func (c *Client) AdminCreateUser(req types.AdminCreateUserRequest) (*types.Admin
 // GET /admin/users
 //
 // Get a list of users.
-func (c *Client) AdminListUsers() (*types.AdminListUsersResponse, error) {
-	r, err := c.newRequest(adminUsersPath, http.MethodGet, nil)
+func (c *Client) AdminListUsers(req types.AdminListUsersRequest) (*types.AdminListUsersResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := c.newRequest(adminUsersPath, http.MethodGet, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}

--- a/integration_test/adminusers_test.go
+++ b/integration_test/adminusers_test.go
@@ -39,7 +39,7 @@ func TestAdminListUsers(t *testing.T) {
 
 	admin := withAdmin(client)
 
-	// Create a user that will be skipped by pagination
+	// Create a user that we know should be returned
 	pass := "password"
 	email := randomEmail()
 	req := types.AdminCreateUserRequest{
@@ -51,20 +51,8 @@ func TestAdminListUsers(t *testing.T) {
 	require.NoError(err)
 	require.Regexp(uuidRegex, createResp.ID)
 
-	// Create a user that we know should be returned
-	pass = "password"
-	email = randomEmail()
-	req = types.AdminCreateUserRequest{
-		Email:    email,
-		Role:     "test",
-		Password: &pass,
-	}
-	createResp, err = admin.AdminCreateUser(req)
-	require.NoError(err)
-	require.Regexp(uuidRegex, createResp.ID)
-
 	// Then list and look up the user we just created
-	page := 1
+	page := 0
 	perPage := 1
 	resp, err := admin.AdminListUsers(types.AdminListUsersRequest{
 		Page:    &page,
@@ -74,9 +62,7 @@ func TestAdminListUsers(t *testing.T) {
 	assert.NotEmpty(resp)
 	for _, u := range resp.Users {
 		assert.NotEqual(uuid.Nil, u.ID)
-		if u.ID == createResp.ID {
-			assert.Equal(u.Email, createResp.Email)
-		}
+		assert.Equal(u.Email, createResp.Email)
 	}
 }
 

--- a/integration_test/adminusers_test.go
+++ b/integration_test/adminusers_test.go
@@ -64,9 +64,11 @@ func TestAdminListUsers(t *testing.T) {
 	require.Regexp(uuidRegex, createResp.ID)
 
 	// Then list and look up the user we just created
+	page := 1
+	perPage := 1
 	resp, err := admin.AdminListUsers(types.AdminListUsersRequest{
-		Page:    1,
-		PerPage: 1,
+		Page:    &page,
+		PerPage: &perPage,
 	})
 	require.NoError(err)
 	assert.NotEmpty(resp)

--- a/integration_test/adminusers_test.go
+++ b/integration_test/adminusers_test.go
@@ -39,7 +39,7 @@ func TestAdminListUsers(t *testing.T) {
 
 	admin := withAdmin(client)
 
-	// Create a user that we know should be returned
+	// Create a user that will be skipped by pagination
 	pass := "password"
 	email := randomEmail()
 	req := types.AdminCreateUserRequest{
@@ -51,8 +51,23 @@ func TestAdminListUsers(t *testing.T) {
 	require.NoError(err)
 	require.Regexp(uuidRegex, createResp.ID)
 
+	// Create a user that we know should be returned
+	pass = "password"
+	email = randomEmail()
+	req = types.AdminCreateUserRequest{
+		Email:    email,
+		Role:     "test",
+		Password: &pass,
+	}
+	createResp, err = admin.AdminCreateUser(req)
+	require.NoError(err)
+	require.Regexp(uuidRegex, createResp.ID)
+
 	// Then list and look up the user we just created
-	resp, err := admin.AdminListUsers()
+	resp, err := admin.AdminListUsers(types.AdminListUsersRequest{
+		Page:    1,
+		PerPage: 1,
+	})
 	require.NoError(err)
 	assert.NotEmpty(resp)
 	for _, u := range resp.Users {

--- a/types/api.go
+++ b/types/api.go
@@ -118,8 +118,8 @@ type AdminCreateUserResponse struct {
 }
 
 type AdminListUsersRequest struct {
-	Page    *int `json:"page,omitempty"`
-	PerPage *int `json:"per_page,omitempty"`
+	Page    *int
+	PerPage *int
 }
 
 type AdminListUsersResponse struct {

--- a/types/api.go
+++ b/types/api.go
@@ -118,8 +118,8 @@ type AdminCreateUserResponse struct {
 }
 
 type AdminListUsersRequest struct {
-	Page    int `json:"page,omitempty"`
-	PerPage int `json:"per_page,omitempty"`
+	Page    *int `json:"page,omitempty"`
+	PerPage *int `json:"per_page,omitempty"`
 }
 
 type AdminListUsersResponse struct {

--- a/types/api.go
+++ b/types/api.go
@@ -117,6 +117,11 @@ type AdminCreateUserResponse struct {
 	User
 }
 
+type AdminListUsersRequest struct {
+	Page    int `json:"page,omitempty"`
+	PerPage int `json:"per_page,omitempty"`
+}
+
 type AdminListUsersResponse struct {
 	Users []User `json:"users"`
 }
@@ -284,10 +289,10 @@ const (
 )
 
 type AuthorizeRequest struct {
-	Provider Provider
+	Provider   Provider
 	RedirectTo string
-	FlowType FlowType
-	Scopes   string
+	FlowType   FlowType
+	Scopes     string
 }
 
 type AuthorizeResponse struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows for custom pagination options when using the `GET /admin/users` Endpoint

## What is the current behavior?

The Endpoint is currently not aware of the optional pagination options.

## What is the new behavior?

Pagination options can be used via the new request body.

## Additional context

None
