### PR TITLE
fix: VerifyForUser return error

### DIFF
--- a/endpoints/verify.go
+++ b/endpoints/verify.go
@@ -139,7 +139,7 @@ func (c *Client) VerifyForUser(req types.VerifyForUserRequest) (*types.VerifyFor
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		fullBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("response status code %d", resp.StatusCode)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix, in `verify.go` file, `VerifyForUser` function

## What is the current behavior?
Supabase returns 200 with a valid response of access token and other user's info, but the if statement from `gotrue` is just checking 303, even the valid responses will be rejected
<img width="291" alt="Screenshot 1447-01-07 at 11 46 38 PM" src="https://github.com/user-attachments/assets/f2463d48-fab9-4640-8ad6-3517dc20d86d" />

in auth-go which is valid but all the endpoints are following the same pattern when checking the response's status codes
<img width="286" alt="Screenshot 1447-01-07 at 11 52 30 PM" src="https://github.com/user-attachments/assets/9dab8f78-68c8-49fc-82d9-657a97a0edaa" />

Please link any relevant issues here.
I encountered the error myself while coding the verifyUser, i also found out there's an active issue describing the same error 
https://github.com/supabase-community/gotrue-go/issues/11

## What is the new behavior?
function now accepts 2xx status code as a valid response, the if aligns with the pattern used in other parts

Feel free to include screenshots if it includes visual changes.

## Additional context
this change was tested with supabase-go and gotrue-go locally

