### PR TITLE
Add redirect_to query parameter to invite, otp, and recover routes.

### DIFF
--- a/endpoints/invite.go
+++ b/endpoints/invite.go
@@ -27,6 +27,12 @@ func (c *Client) Invite(req types.InviteRequest) (*types.InviteResponse, error) 
 		return nil, err
 	}
 
+	if req.RedirectTo != "" {
+		q := r.URL.Query()
+		q.Add("redirect_to", req.RedirectTo)
+		r.URL.RawQuery = q.Encode()
+	}
+
 	resp, err := c.client.Do(r)
 	if err != nil {
 		return nil, err

--- a/endpoints/otp.go
+++ b/endpoints/otp.go
@@ -29,6 +29,12 @@ func (c *Client) OTP(req types.OTPRequest) error {
 		return err
 	}
 
+	if req.RedirectTo != "" {
+		q := r.URL.Query()
+		q.Add("redirect_to", req.RedirectTo)
+		r.URL.RawQuery = q.Encode()
+	}
+
 	resp, err := c.client.Do(r)
 	if err != nil {
 		return err

--- a/endpoints/recover.go
+++ b/endpoints/recover.go
@@ -29,6 +29,12 @@ func (c *Client) Recover(req types.RecoverRequest) error {
 		return err
 	}
 
+	if req.RedirectTo != "" {
+		q := r.URL.Query()
+		q.Add("redirect_to", req.RedirectTo)
+		r.URL.RawQuery = q.Encode()
+	}
+
 	resp, err := c.client.Do(r)
 	if err != nil {
 		return err

--- a/types/api.go
+++ b/types/api.go
@@ -365,8 +365,9 @@ type HealthCheckResponse struct {
 }
 
 type InviteRequest struct {
-	Email string                 `json:"email"`
-	Data  map[string]interface{} `json:"data"`
+	Email      string                 `json:"email"`
+	Data       map[string]interface{} `json:"data"`
+	RedirectTo string                 `json:"-"`
 }
 
 type InviteResponse struct {
@@ -386,13 +387,15 @@ type OTPRequest struct {
 	Phone      string                 `json:"phone"`
 	CreateUser bool                   `json:"create_user"`
 	Data       map[string]interface{} `json:"data"`
+	RedirectTo string                 `json:"-"`
 
 	// Provide Captcha token if enabled.
 	SecurityEmbed
 }
 
 type RecoverRequest struct {
-	Email string `json:"email"`
+	Email      string `json:"email"`
+	RedirectTo string `json:"-"`
 
 	// Provide Captcha token if enabled.
 	SecurityEmbed


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/feature implementation (depending on your perspective). Addresses issue #13 

## What is the current behavior?

Currently, there is not way to submit a redirect URL for only some routes (invite, otp, and recover). If there are any that I missed I can add them.

## What is the new behavior?

Implements redirect URLs by adding a parameter to the associated types. This parameter gets added the URL as a query parameter if it exists. The RedirectTo parameter will not be included in the request body as it has a `json:"-"` tag.

## Additional context

Add any other context or screenshots.
